### PR TITLE
Integrate symgc in druntime (v1.43.x)

### DIFF
--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -212,5 +212,10 @@ runs:
       shell: bash
       run: |
         set -eux
-        DFLAGS="-singleobj -g" dub build --root=runtime/symgc --build=release-nobounds
-        ls -l runtime/symgc/libsymgc.a
+        cd runtime/symgc
+        DFLAGS="-singleobj -g" dub build --build=release-nobounds
+        ls -l libsymgc.a
+        # extract single object file as symgc.o
+        ar x libsymgc.a
+        mv *.o symgc.o
+        ls -l symgc.o

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -206,3 +206,11 @@ runs:
         echo "CFLAGS=-m32" >> $GITHUB_ENV
         echo "CXXFLAGS=-m32" >> $GITHUB_ENV
         echo "ASMFLAGS=-m32" >> $GITHUB_ENV
+
+    - name: 'Linux x86_64: Build symgc'
+      if: runner.os == 'Linux' && inputs.arch == 'x86_64'
+      shell: bash
+      run: |
+        set -eux
+        DFLAGS="-singleobj -g" dub build --root=runtime/symgc --build=release-nobounds
+        ls -l runtime/symgc/libsymgc.a

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -95,15 +95,9 @@ runs:
 
         arch='${{ inputs.arch }}'
 
-        # use assertions for untagged builds
-        assertsSuffix="-withAsserts"
-        if [[ '${{ github.ref }}' = refs/tags/* ]]; then
-          assertsSuffix=""
-        fi
-
         if [[ '${{ runner.os }}' == Windows ]]; then
           curl -fL --retry 3 --max-time 300 -o llvm.7z \
-            https://github.com/ldc-developers/llvm-project/releases/download/$tag/llvm-$version-windows-$arch$assertsSuffix.7z
+            https://github.com/ldc-developers/llvm-project/releases/download/$tag/llvm-$version-windows-$arch.7z
           mkdir llvm
           cd llvm
           7z x ../llvm.7z >/dev/null
@@ -116,7 +110,7 @@ runs:
             os=osx
           fi
           curl -fL --retry 3 --max-time 300 -o llvm.tar.zst \
-            https://github.com/ldc-developers/llvm-project/releases/download/$tag/llvm-$version-$os-$arch$assertsSuffix.tar.zst
+            https://github.com/ldc-developers/llvm-project/releases/download/$tag/llvm-$version-$os-$arch.tar.zst
           mkdir llvm
           tar -xf llvm.tar.zst --zstd --strip 1 -C llvm
           rm llvm.tar.zst

--- a/.github/actions/1-setup/action.yml
+++ b/.github/actions/1-setup/action.yml
@@ -206,16 +206,3 @@ runs:
         echo "CFLAGS=-m32" >> $GITHUB_ENV
         echo "CXXFLAGS=-m32" >> $GITHUB_ENV
         echo "ASMFLAGS=-m32" >> $GITHUB_ENV
-
-    - name: 'Linux x86_64: Build symgc'
-      if: runner.os == 'Linux' && inputs.arch == 'x86_64'
-      shell: bash
-      run: |
-        set -eux
-        cd runtime/symgc
-        DFLAGS="-singleobj -g" dub build --build=release-nobounds
-        ls -l libsymgc.a
-        # extract single object file as symgc.o
-        ar x libsymgc.a
-        mv *.o symgc.o
-        ls -l symgc.o

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -12,19 +12,28 @@ runs:
   using: composite
   steps:
 
-    - name: 'Linux x86_64: Build symgc'
-      if: runner.os == 'Linux' && inputs.arch == 'x86_64'
+    - name: 'Linux & Windows x86_64: Build symgc'
+      if: (runner.os == 'Linux' && inputs.arch == 'x86_64') || (runner.os == 'Windows' && inputs.arch == 'x64')
       shell: bash
       run: |
         set -eux
         cd runtime/symgc
         # FIXME: hitting LLVM assertion with -g
         DFLAGS="-O -g -singleobj -linkonce-templates" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
-        ls -l libsymgc.a
-        # extract single object file as symgc.o
-        ar x libsymgc.a
-        mv *.o symgc.o
-        ls -l symgc.o
+        # extract single object file as symgc.o[bj]
+        if [[ '${{ runner.os }}' == Linux ]]; then
+          ls -l libsymgc.a
+          ar x libsymgc.a
+          mv *.o symgc.o
+          ls -l symgc.o
+        else
+          ls -l symgc.lib
+          #obj=$(lib.exe /nologo /list symgc.lib)
+          #lib.exe /nologo symgc.lib /extract:"$obj" /out:symgc.obj
+          llvm-ar x symgc.lib
+          mv *.obj symgc.obj
+          ls -l symgc.obj
+        fi
 
     - name: 'Posix: Build mimalloc'
       if: runner.os != 'Windows'

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -19,7 +19,7 @@ runs:
         set -eux
         cd runtime/symgc
         # FIXME: hitting LLVM assertion with -g
-        DFLAGS="-O -g -singleobj" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
+        DFLAGS="-O -g -singleobj -linkonce-templates" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
         ls -l libsymgc.a
         # extract single object file as symgc.o
         ar x libsymgc.a

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -17,10 +17,6 @@ runs:
       shell: bash
       run: |
         set -eux
-        if ! type -P dub &>/dev/null; then
-          echo "No dub from host compiler in PATH (expected on Alpine), skipping symgc build."
-          exit 0
-        fi
         cd runtime/symgc
         # FIXME: hitting LLVM assertion with -g
         DFLAGS="-O -g -singleobj" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -12,8 +12,8 @@ runs:
   using: composite
   steps:
 
-    - name: 'Linux & Windows x86_64: Build symgc'
-      if: (runner.os == 'Linux' && inputs.arch == 'x86_64') || (runner.os == 'Windows' && inputs.arch == 'x64')
+    - name: 'Linux(aarch64/x86_64) & Windows(x86_64): Build symgc'
+      if: (runner.os == 'Linux' && (inputs.arch == 'x86_64' || inputs.arch == 'aarch64')) || (runner.os == 'Windows' && inputs.arch == 'x64')
       shell: bash
       run: |
         set -eux

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -12,6 +12,19 @@ runs:
   using: composite
   steps:
 
+    - name: 'Linux x86_64: Build symgc'
+      if: runner.os == 'Linux' && inputs.arch == 'x86_64'
+      shell: bash
+      run: |
+        set -eux
+        cd runtime/symgc
+        DFLAGS="-singleobj -g" dub build --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2 --build=release-nobounds
+        ls -l libsymgc.a
+        # extract single object file as symgc.o
+        ar x libsymgc.a
+        mv *.o symgc.o
+        ls -l symgc.o
+
     - name: 'Posix: Build mimalloc'
       if: runner.os != 'Windows'
       uses: ./.github/actions/helper-mimalloc

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -23,7 +23,7 @@ runs:
         fi
         cd runtime/symgc
         # FIXME: hitting LLVM assertion with -g
-        DFLAGS="-O -gline-tables-only -singleobj" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
+        DFLAGS="-O -g -singleobj" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
         ls -l libsymgc.a
         # extract single object file as symgc.o
         ar x libsymgc.a

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -17,8 +17,13 @@ runs:
       shell: bash
       run: |
         set -eux
+        if ! type -P dub &>/dev/null; then
+          echo "No dub from host compiler in PATH (expected on Alpine), skipping symgc build."
+          exit 0
+        fi
         cd runtime/symgc
-        DFLAGS="-singleobj -g" dub build --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2 --build=release-nobounds
+        # FIXME: hitting LLVM assertion with -g
+        DFLAGS="-O -gline-tables-only -singleobj" dub build -v --compiler=$PWD/../../../bootstrap-ldc/bin/ldc2
         ls -l libsymgc.a
         # extract single object file as symgc.o
         ar x libsymgc.a

--- a/.github/actions/3-build-native/action.yml
+++ b/.github/actions/3-build-native/action.yml
@@ -13,8 +13,8 @@ runs:
   steps:
 
     - name: 'Linux(aarch64/x86_64) & Windows(x86_64): Build symgc'
-      if: (runner.os == 'Linux' && (inputs.arch == 'x86_64' || inputs.arch == 'aarch64')) || (runner.os == 'Windows' && inputs.arch == 'x64')
-      shell: bash
+      if: (runner.os == 'Linux' && (inputs.arch == 'x86_64' || inputs.arch == 'aarch64') && !startsWith(env.GHA_BASH_SHELL, 'cpa.sh')) || (runner.os == 'Windows' && inputs.arch == 'x64')
+      shell: ${{ env.GHA_BASH_SHELL }}
       run: |
         set -eux
         cd runtime/symgc

--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -8,7 +8,7 @@ runs:
 
     - name: Generate hello.d
       shell: ${{ env.GHA_BASH_SHELL }}
-      run: echo 'void main() { import std.stdio; writefln("Hello world, %d bits", size_t.sizeof * 8); }' > ../hello.d
+      run: echo 'void main() { import std.stdio; writefln("Hello world, %d bits", size_t.sizeof * 8); auto dummyAlloc = new int; }' > ../hello.d
 
     - name: Run hello-world integration test with shared libs
       shell: ${{ env.GHA_BASH_SHELL }}
@@ -22,6 +22,8 @@ runs:
         installed/bin/ldc2 hello.d -link-defaultlib-shared
         ./hello
         if [[ -f ${{ github.workspace }}/runtime/symgc/symgc.o ]]; then
+          ./hello --DRT-gcopt="gc:sdc"
+          installed/bin/ldc2 hello.d
           ./hello --DRT-gcopt="gc:sdc"
         fi
         if [[ -d installed/lib32 ]]; then

--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -21,7 +21,7 @@ runs:
         fi
         installed/bin/ldc2 hello.d -link-defaultlib-shared
         ./hello
-        if [[ '${{ runner.os }}-${{ inputs.arch }}' == Linux-x86_64 ]]; then
+        if [[ -f ${{ github.workspace }}/runtime/symgc/symgc.o ]]; then
           ./hello --DRT-gcopt="gc:sdc"
         fi
         if [[ -d installed/lib32 ]]; then

--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -25,6 +25,7 @@ runs:
           ./hello --DRT-gcopt="gc:sdc"
           installed/bin/ldc2 hello.d
           ./hello --DRT-gcopt="gc:sdc"
+          DRT_GCOPT="gc:sdc" ./hello
         fi
         if [[ -d installed/lib32 ]]; then
           installed/bin/ldc2 hello.d -m32 -link-defaultlib-shared

--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -14,6 +14,10 @@ runs:
       shell: ${{ env.GHA_BASH_SHELL }}
       run: |
         set -eux
+        symgc=0
+        if [[ -f runtime/symgc/symgc.o || -f runtime/symgc/symgc.obj ]]; then
+          symgc=1
+        fi
         cd ..
         if [[ '${{ runner.os }}' == Windows ]]; then
           # add druntime/Phobos DLL dir to PATH
@@ -21,7 +25,7 @@ runs:
         fi
         installed/bin/ldc2 hello.d -link-defaultlib-shared
         ./hello
-        if [[ -f ${{ github.workspace }}/runtime/symgc/symgc.o ]]; then
+        if [[ $symgc == 1 ]]; then
           ./hello --DRT-gcopt="gc:sdc"
           installed/bin/ldc2 hello.d
           ./hello --DRT-gcopt="gc:sdc"

--- a/.github/actions/6-integration-test/action.yml
+++ b/.github/actions/6-integration-test/action.yml
@@ -21,6 +21,9 @@ runs:
         fi
         installed/bin/ldc2 hello.d -link-defaultlib-shared
         ./hello
+        if [[ '${{ runner.os }}-${{ inputs.arch }}' == Linux-x86_64 ]]; then
+          ./hello --DRT-gcopt="gc:sdc"
+        fi
         if [[ -d installed/lib32 ]]; then
           installed/bin/ldc2 hello.d -m32 -link-defaultlib-shared
           ./hello

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
           else
             # set up Alpine container
             apk add \
-              git cmake ninja-is-really-ninja g++ clang ldc lld llvm-dev llvm-static compiler-rt \
+              git cmake ninja-is-really-ninja g++ clang ldc dub lld llvm-dev llvm-static compiler-rt \
               libxml2-static zstd-static zlib-static \
               bash grep diffutils make curl 7zip perl
             # make lld the default linker (note: /usr/bin/ld seems unused)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ concurrency:
 env:
   LLVM_VERSION: 22.1.8
   CLANG_MAJOR: 22
+  DRT_GCOPT: gc:conservative
 
 jobs:
   build-native:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches-ignore:
       - 'merge-*' # don't run on pushes to merge-X.Y.Z branches, they are usually PRs
-      - symgc
+      - 'symgc*'
     tags: # explicitly needed to run for all tags, due to the branches filter above
       - '**'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches-ignore:
       - 'merge-*' # don't run on pushes to merge-X.Y.Z branches, they are usually PRs
+      - symgc
     tags: # explicitly needed to run for all tags, due to the branches filter above
       - '**'
 

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches-ignore:
       - 'merge-*' # don't run on pushes to merge-X.Y.Z branches, they are usually PRs
-      - symgc
+      - 'symgc*'
     tags: # explicitly needed to run for all tags, due to the branches filter above
       - '**'
 

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches-ignore:
       - 'merge-*' # don't run on pushes to merge-X.Y.Z branches, they are usually PRs
+      - symgc
     tags: # explicitly needed to run for all tags, due to the branches filter above
       - '**'
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "phobos"]
 	path = runtime/phobos
 	url = https://github.com/ldc-developers/phobos.git
+[submodule "runtime/symgc"]
+	path = runtime/symgc
+	url = https://github.com/symmetryinvestments/symgc.git

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -562,9 +562,13 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
     else()
         set(single_obj_name "")
     endif()
+    set(symgc_version "")
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o" AND "${path_suffix}" STREQUAL "${LIB_SUFFIX}") # not for 32-bit druntime with MULTILIB=ON
+        set(symgc_version "-d-version=With_symgc")
+    endif()
     dc("${DRUNTIME_D}"
        "${RUNTIME_DIR}/src"
-       "-conf=;${d_flags};${DRUNTIME_EXTRA_FLAGS};-I${RUNTIME_DIR}/src"
+       "-conf=;${d_flags};${symgc_version};${DRUNTIME_EXTRA_FLAGS};-I${RUNTIME_DIR}/src"
        "${PROJECT_BINARY_DIR}/objects${target_suffix}"
        "${emit_bc}"
        "${all_at_once}"
@@ -572,9 +576,10 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
        ${outlist_o}
        ${outlist_bc}
     )
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o")
-        if("${path_suffix}" STREQUAL "${LIB_SUFFIX}") # not for 32-bit druntime with MULTILIB=ON
-            list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
+    if(symgc_version)
+        list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
+        if(${emit_bc})
+            list(APPEND ${outlist_bc} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
         endif()
     endif()
 endmacro()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -563,7 +563,7 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
         set(single_obj_name "")
     endif()
     set(symgc_version "")
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o" AND "${path_suffix}" STREQUAL "${LIB_SUFFIX}") # not for 32-bit druntime with MULTILIB=ON
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc${CMAKE_C_OUTPUT_EXTENSION}" AND "${path_suffix}" STREQUAL "${LIB_SUFFIX}") # not for 32-bit druntime with MULTILIB=ON
         set(symgc_version "-d-version=With_symgc")
     endif()
     dc("${DRUNTIME_D}"
@@ -577,9 +577,9 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
        ${outlist_bc}
     )
     if(symgc_version)
-        list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
+        list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc${CMAKE_C_OUTPUT_EXTENSION})
         if(${emit_bc})
-            list(APPEND ${outlist_bc} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
+            list(APPEND ${outlist_bc} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc${CMAKE_C_OUTPUT_EXTENSION})
         endif()
     endif()
 endmacro()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -573,7 +573,7 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
        ${outlist_bc}
     )
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o")
-        if((NOT CMAKE_CROSSCOMPILING) AND ("${TARGET_SYSTEM}" MATCHES "Linux") AND ("${path_suffix}" STREQUAL "${LIB_SUFFIX}"))
+        if("${path_suffix}" STREQUAL "${LIB_SUFFIX}") # not for 32-bit druntime with MULTILIB=ON
             list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
         endif()
     endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -663,6 +663,12 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
     # C executables.
     if("${is_shared}" STREQUAL "ON")
         target_link_libraries(druntime-ldc${target_suffix} ${C_SYSTEM_LIBS_SHARED})
+
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/libsymgc.a")
+            if((NOT CMAKE_CROSSCOMPILING) AND ("${TARGET_SYSTEM}" MATCHES "Linux") AND ("${path_suffix}" STREQUAL "${LIB_SUFFIX}"))
+                target_link_libraries(druntime-ldc${target_suffix} "-Wl,--whole-archive,${CMAKE_CURRENT_SOURCE_DIR}/symgc/libsymgc.a,--no-whole-archive")
+            endif()
+        endif()
     endif()
 
     list(APPEND ${outlist_targets} druntime-ldc${target_suffix})

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -572,6 +572,11 @@ macro(compile_druntime d_flags lib_suffix path_suffix emit_bc all_at_once single
        ${outlist_o}
        ${outlist_bc}
     )
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o")
+        if((NOT CMAKE_CROSSCOMPILING) AND ("${TARGET_SYSTEM}" MATCHES "Linux") AND ("${path_suffix}" STREQUAL "${LIB_SUFFIX}"))
+            list(APPEND ${outlist_o} ${CMAKE_CURRENT_SOURCE_DIR}/symgc/symgc.o)
+        endif()
+    endif()
 endmacro()
 
 # Sets up the targets for building the Phobos D object files, appending the
@@ -663,12 +668,6 @@ macro(build_runtime_libs druntime_o druntime_bc phobos2_o phobos2_bc c_flags ld_
     # C executables.
     if("${is_shared}" STREQUAL "ON")
         target_link_libraries(druntime-ldc${target_suffix} ${C_SYSTEM_LIBS_SHARED})
-
-        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/symgc/libsymgc.a")
-            if((NOT CMAKE_CROSSCOMPILING) AND ("${TARGET_SYSTEM}" MATCHES "Linux") AND ("${path_suffix}" STREQUAL "${LIB_SUFFIX}"))
-                target_link_libraries(druntime-ldc${target_suffix} "-Wl,--whole-archive,${CMAKE_CURRENT_SOURCE_DIR}/symgc/libsymgc.a,--no-whole-archive")
-            endif()
-        endif()
     endif()
 
     list(APPEND ${outlist_targets} druntime-ldc${target_suffix})

--- a/runtime/druntime/src/core/gc/config.d
+++ b/runtime/druntime/src/core/gc/config.d
@@ -19,7 +19,10 @@ struct Config
     bool disable;            // start disabled
     bool fork = false;       // optional concurrent behaviour
     ubyte profile;           // enable profiling with summary when terminating program
-    string gc = "conservative"; // select gc implementation conservative|precise|manual
+    version (With_symgc)
+        string gc = "sdcq"; // pick the symgc in quiet mode by default.
+    else
+        string gc = "conservative"; // select gc implementation conservative|precise|manual
 
     @MemVal size_t initReserve;      // initial reserve (bytes)
     @MemVal size_t minPoolSize = 1  << 20;  // initial and minimum pool size (bytes)
@@ -62,7 +65,7 @@ struct Config
         auto _minPoolSize = minPoolSize.bytes2prettyStruct;
         auto _maxPoolSize = maxPoolSize.bytes2prettyStruct;
         auto _incPoolSize = incPoolSize.bytes2prettyStruct;
-        printf(" - select gc implementation (default = conservative)
+        printf(" - select gc implementation (default = %.*s)
 
     initReserve:N  - initial memory to reserve in MB (%lld%c)
     minPoolSize:N  - initial and minimum pool size in MB (%lld%c)
@@ -74,6 +77,7 @@ struct Config
 
     Memory-related values can use B, K, M or G suffixes.
 ".ptr,
+               cast(int)gc.length, gc.ptr,
                _initReserve.v, _initReserve.u,
                _minPoolSize.v, _minPoolSize.u,
                _maxPoolSize.v, _maxPoolSize.u,

--- a/runtime/druntime/src/core/internal/gc/proxy.d
+++ b/runtime/druntime/src/core/internal/gc/proxy.d
@@ -37,6 +37,7 @@ extern (C)
     // do not import GC modules, they might add a dependency to this whole module
     void _d_register_conservative_gc();
     void _d_register_manual_gc();
+    version (With_symgc) void _d_register_sdc_gc();
 
     // if you don't want to include the default GCs, replace during link by another implementation
     void* register_default_gcs() @weak
@@ -46,7 +47,15 @@ extern (C)
         // avoid being optimized away
         auto reg1 = &_d_register_conservative_gc;
         auto reg2 = &_d_register_manual_gc;
-        return reg1 < reg2 ? reg1 : reg2;
+        version (With_symgc)
+        {
+            auto reg3 = &_d_register_sdc_gc;
+            return reg1 < reg2 ? reg1 : reg2 < reg3 ? reg2 : reg3;
+        }
+        else
+        {
+            return reg1 < reg2 ? reg1 : reg2;
+        }
     }
 
     void gc_init()

--- a/runtime/druntime/src/rt/config.d
+++ b/runtime/druntime/src/rt/config.d
@@ -49,7 +49,10 @@ version (LDC) // use @weak
 
     extern(C) __gshared @weak
     {
-        pragma(mangle, "rt_envvars_enabled") bool _rt_envvars_enabled = false;
+        version (With_symgc)
+            pragma(mangle, "rt_envvars_enabled") bool _rt_envvars_enabled = true;
+        else
+            pragma(mangle, "rt_envvars_enabled") bool _rt_envvars_enabled = false;
         pragma(mangle, "rt_cmdline_enabled") bool _rt_cmdline_enabled = true;
         pragma(mangle, "rt_options") string[] _rt_options = [];
     }

--- a/runtime/druntime/test/exceptions/src/unknown_gc.d
+++ b/runtime/druntime/test/exceptions/src/unknown_gc.d
@@ -1,5 +1,6 @@
 import core.memory;
 
+extern(C) __gshared bool rt_envvars_enabled = false;
 extern(C) __gshared string[] rt_options = [ "gcopt=gc:unknowngc" ];
 
 void main()


### PR DESCRIPTION
This is #8 rebased onto `sym-1.43.x`:
- Include [symgc](https://github.com/symmetryinvestments/symgc) in prebuilt (static & shared) druntime libraries as **default** GC on supported targets:
  - Linux x86_64 & AArch64, incl. Alpine musl but excl. Android
  - Windows x86_64
- On these supported targets, also enable special druntime `DRT_*` environment variables support by default. This allows simple switching/comparison via e.g. `DRT_GCOPT=gc:conservative` for a whole process tree and/or system. [An explicit command-line switch `--DRT-gcopt=gc:conservative` for a single process works too.]